### PR TITLE
Fix two problems I (and other people) have reported on Steam

### DIFF
--- a/1.4/Source/HaulToBuilding/Dialog_BillConfig_Patches.cs
+++ b/1.4/Source/HaulToBuilding/Dialog_BillConfig_Patches.cs
@@ -198,9 +198,11 @@ public class Dialog_BillConfig_Patches
                     {
                         case Zone_Stockpile stockpile:
                             dialog.bill.includeFromZone = stockpile;
+                            extraData.LookInStorage = null;
                             break;
                         case Building_Storage b:
                             extraData.LookInStorage = b;
+                            dialog.bill.includeFromZone = null;
                             GameComponent_ExtraBillData.Instance.SetData(dialog.bill, extraData);
                             break;
                     }

--- a/1.4/Source/HaulToBuilding/Toils_Recipe_Patches.cs
+++ b/1.4/Source/HaulToBuilding/Toils_Recipe_Patches.cs
@@ -45,8 +45,8 @@ namespace HaulToBuilding
             var list2 = new[]
             {
                 new CodeInstruction(OpCodes.Ldloc_0),
-                new CodeInstruction(OpCodes.Ldloc_S, 5),
-                new CodeInstruction(OpCodes.Ldloca_S, 7),
+                new CodeInstruction(OpCodes.Ldloc_S, 6),
+                new CodeInstruction(OpCodes.Ldloca_S, 9),
                 new CodeInstruction(OpCodes.Call,
                     AccessTools.Method(typeof(Toils_Recipe_Patches), "FindCell")),
                 new CodeInstruction(OpCodes.Brtrue_S, label2)


### PR DESCRIPTION
* update for changed Toils_Recipe.FinishRecipeAndStartStoringProduct()
The code has changed, so locals have moved in the list.
*  fix switch from zone to building in 'Look in'
Have at least one shelf and one zone, going from 'Look everywhere"
to "Look in shelf" works, but going from "Look in stockpile zone 1"
to "Look in shelf" doesn't.
